### PR TITLE
Added Timezone to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ mysql -uroot -p'openspecimen' (or your set MYSQL_ROOT_PASSWORD)
 
 update catissue_user set password = '$2a$10$GOH1.KmElP0ZusLYS6l12ejO.xAIzDUFpIm7LVz9xAcrObyvd3gLC' where identifier = 2;
 
+-------------------------------------------------------------------------------------------
 
+Set correct timezone in docker-comose.yml, otherwise dates displayed in OpenSpecimen and labels may not match. E.g. TZ=Etc/GMT-2. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - MYSQL_DATABASE=openspecimen
       - MYSQL_USER=openspecimen
       - MYSQL_PASSWORD=openspecimen
+      - TZ=Etc/GMT-2
     depends_on:
       - local-openspecimen-db
     volumes:


### PR DESCRIPTION
Explicitly sets timezone to avoid an issue where the dates on labels and displayed dates in OpenSpecimen don't match.

Updated README.md to reflect changes.